### PR TITLE
Fixed issue with Unity3D solutions handling

### DIFF
--- a/NamespaceFixer/NamespaceBuilder/NamespaceBuilderService.cs
+++ b/NamespaceFixer/NamespaceBuilder/NamespaceBuilderService.cs
@@ -46,6 +46,10 @@ namespace NamespaceFixer.NamespaceBuilder
 
         private string GetProjectToSolutionPysicalPath(FileInfo solutionFile, FileInfo projectFile)
         {
+            var projectAndSolutionFilesAreSameDirectory = projectFile.Directory.FullName.Equals(solutionFile.Directory.FullName);
+            if (projectAndSolutionFilesAreSameDirectory)
+                return string.Empty;
+
             return projectFile.Directory.FullName.Substring(solutionFile.Directory.FullName.Length + 1);
         }
 


### PR DESCRIPTION
Unity3D solutions create project files (*.csproj) in the same directory as solution file (*.sln). Thia was causing an error in Substring method, because length parameter was too high.