### PR TITLE
Add support for Visual Studio 2019

### DIFF
--- a/NamespaceFixer/source.extension.vsixmanifest
+++ b/NamespaceFixer/source.extension.vsixmanifest
@@ -8,13 +8,13 @@
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
-        <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />

--- a/NamespaceFixer/source.extension.vsixmanifest
+++ b/NamespaceFixer/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="pch9d11e-9ed1-48f6-875b-4d144a5d790c" Version="1.5" Language="en-US" Publisher="pcerv" />
+        <Identity Id="pch9d11e-9ed1-48f6-875b-4d144a5d790c" Version="1.6" Language="en-US" Publisher="pcerv" />
         <DisplayName>NamespaceFixer</DisplayName>
         <Description xml:space="preserve">VS Extension to fix namespaces following C# convention</Description>
         <Icon>Package.ico</Icon>


### PR DESCRIPTION
Closes #9 

This PR covers the following changes

- Widen range of `InstallationTarget`
- Widen range of `Prerequisite`
- Bump version one minor unit