### PR TITLE
Correctly finds namespace when { is on the same line.

### DIFF
--- a/NamespaceFixer/NamespaceBuilder/CsNamespaceBuilderService.cs
+++ b/NamespaceFixer/NamespaceBuilder/CsNamespaceBuilderService.cs
@@ -14,7 +14,7 @@ namespace NamespaceFixer.NamespaceBuilder
 
         protected override Match FindNamespaceMatch(string fileContent)
         {
-            return Regex.Match(fileContent, @"[\r\n|\r|\n]?namespace\s(.+)[\r\n|\r|\n]+{");
+            return Regex.Match(fileContent, @"[\r\n|\r|\n]?namespace\s(.+)[\r\n|\r|\n]*{");
         }
 
         protected override MatchCollection FindUsingMatches(string fileContent)


### PR DESCRIPTION
I kept having issues with this extension.  I found that this was the cause, if the { is on the same line as the namespace declaration it will create a new namespace wrapping the existing one.