### PR TITLE
XAML files compatibility

### DIFF
--- a/NamespaceFixer/NamespaceAdjuster.cs
+++ b/NamespaceFixer/NamespaceAdjuster.cs
@@ -77,8 +77,8 @@ namespace NamespaceFixer
 
                 foreach (var filePath in allPaths.ToList())
                 {
-                    var builder = NamespaceBuilderFactory.CreateNamespaceBuilderService(projectFile.Extension, _package.GetOptionPage());
-                    allPaths.ToList().ForEach(f => FixNamespace(builder, f, solutionFile, projectFile));
+                    var builder = NamespaceBuilderFactory.CreateNamespaceBuilderService(projectFile.Extension, _package.GetOptionPage(), filePath);
+                    FixNamespace(builder, filePath, solutionFile, projectFile);
                 }
             }
             finally

--- a/NamespaceFixer/NamespaceBuilder/NamespaceBuilderFactory.cs
+++ b/NamespaceFixer/NamespaceBuilder/NamespaceBuilderFactory.cs
@@ -1,32 +1,36 @@
 using NamespaceFixer.Core;
 using System;
+using System.IO;
 
 namespace NamespaceFixer.NamespaceBuilder
 {
     internal class NamespaceBuilderFactory
     {
-        internal static INamespaceBuilder CreateNamespaceBuilderService(string extension, INamespaceAdjusterOptions options)
+        internal static INamespaceBuilder CreateNamespaceBuilderService(string extension, INamespaceAdjusterOptions options, string filePath)
         {
-            INamespaceBuilder rslt = null;
             string projectName = ProjectHelper.GetProjectExtensionName(extension);
+            string fileExtension = Path.GetExtension(filePath);
 
-            switch (projectName)
+            if(projectName == Statics.CsProjectFileExtension)
             {
-                case Statics.CsProjectFileExtension:
-                    rslt = new CsNamespaceBuilderService(options);
-                    break;
-
-                case Statics.VbProjectFileExtension:
-                    rslt = new VbNamespaceBuilderService(options);
-                    break;
+                switch (fileExtension)
+                {
+                    case "cs":
+                        return new CsNamespaceBuilderService(options);
+                    case "xaml":
+                        return new XamlNamespaceBuilderService(options);
+                    default:
+                        throw new Exception($"Unsupported file extension '{fileExtension}'.");
+                }
             }
-
-            if (rslt is null)
+            else if(projectName == Statics.VbProjectFileExtension)
+            {
+                return new VbNamespaceBuilderService(options);
+            }
+            else
             {
                 throw new Exception($"Unsupported project file '{projectName}'.");
             }
-
-            return rslt;
         }
 
     }

--- a/NamespaceFixer/NamespaceBuilder/NamespaceBuilderFactory.cs
+++ b/NamespaceFixer/NamespaceBuilder/NamespaceBuilderFactory.cs
@@ -15,9 +15,9 @@ namespace NamespaceFixer.NamespaceBuilder
             {
                 switch (fileExtension)
                 {
-                    case "cs":
+                    case ".cs":
                         return new CsNamespaceBuilderService(options);
-                    case "xaml":
+                    case ".xaml":
                         return new XamlNamespaceBuilderService(options);
                     default:
                         throw new Exception($"Unsupported file extension '{fileExtension}'.");

--- a/NamespaceFixer/NamespaceBuilder/XamlNamespaceBuilderService.cs
+++ b/NamespaceFixer/NamespaceBuilder/XamlNamespaceBuilderService.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.IO;
+using System.IO.Extensions;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace NamespaceFixer.NamespaceBuilder
+{
+    internal class XamlNamespaceBuilderService : INamespaceBuilder
+    {
+        public XamlNamespaceBuilderService(INamespaceAdjusterOptions options)
+        {
+            _options = options;
+        }
+
+        protected Match FindNamespaceMatch(string fileContent)
+        {
+            return Regex.Match(fileContent, @"x:Class=""([a-zA-Z0-9_\.]+)\.[a-zA-Z0-9_]+""");
+        }
+
+        public string GetNamespace(string filePath, FileInfo solutionFile, FileInfo projectFile)
+        {
+            var solutionName = solutionFile.NameWithoutExtension();
+            var projectName = projectFile.NameWithoutExtension();
+            var projectRootNamespace = GetRootNamespaceFromProject(projectFile);
+            var projectToSolutionPhysicalPath = GetProjectToSolutionPhysicalPath(solutionFile, projectFile);
+            var projectToSolutionVirtualPath = string.Empty; // GetProjectToSolutionVirtualPath(solutionFile, projectFile);
+            var fileToProjectPath = GetFileToProjectPath(projectFile, filePath);
+
+            string result = BuildNamespaceAccordingToOptions(
+                solutionName,
+                projectName,
+                projectRootNamespace,
+                projectToSolutionPhysicalPath,
+                projectToSolutionVirtualPath,
+                fileToProjectPath);
+
+            return ToValidFormat(result);
+        }
+
+        public bool UpdateFile(ref string fileContent, string desiredNamespace)
+        {
+            if (string.IsNullOrEmpty(desiredNamespace)) return false;
+
+            var namespaceMatch = FindNamespaceMatch(fileContent);
+
+            return namespaceMatch.Success ?
+                UpdateNamespace(ref fileContent, desiredNamespace, namespaceMatch) :
+                CreateNamespace(ref fileContent, desiredNamespace);
+        }
+
+        private bool UpdateNamespace(ref string fileContent, string desiredNamespace, Match namespaceMatch)
+        {
+            var fileRequiresUpdate = false;
+
+            var namespaceGroup = namespaceMatch.Groups.OfType<Group>().Where(g => !(g is Match)).FirstOrDefault();
+
+            if (namespaceGroup == null) return false;
+
+            var currentNamespace = namespaceGroup.Value.Trim();
+
+            if (currentNamespace != desiredNamespace)
+            {
+                fileRequiresUpdate = true;
+                fileContent = fileContent.Substring(0, namespaceGroup.Index) + desiredNamespace + fileContent.Substring(namespaceGroup.Index + namespaceGroup.Value.Trim().Length);
+            }
+
+            return fileRequiresUpdate;
+        }
+
+        private bool CreateNamespace(ref string fileContent, string desiredNamespace)
+        {
+            return false;
+        }
+
+        private string GetRootNamespaceFromProject(FileInfo projectFile)
+        {
+            using (var reader = BuildXmlProjectFileReader(projectFile))
+            {
+                while (reader.Read())
+                {
+                    if (reader.NodeType == XmlNodeType.Element && reader.Name == "RootNamespace")
+                    {
+                        reader.Read();
+
+                        return reader.NodeType == XmlNodeType.Text ? reader.Value : null;
+                    }
+                }
+            }
+            return Path.GetFileNameWithoutExtension(projectFile.FullName);
+        }
+
+        private XmlReader BuildXmlProjectFileReader(FileInfo projectFile)
+        {
+            XmlReaderSettings settings = new XmlReaderSettings();
+            settings.DtdProcessing = DtdProcessing.Parse;
+            return XmlReader.Create(projectFile.FullName, settings);
+        }
+
+        private string GetFileToProjectPath(FileInfo projectFile, string filePath)
+        {
+            return Directory.GetParent(filePath).FullName.Substring(projectFile.Directory.FullName.Length);
+        }
+
+        private string GetProjectToSolutionPhysicalPath(FileInfo solutionFile, FileInfo projectFile)
+        {
+            string solutionDirectoryFullName = solutionFile.Directory.FullName;
+            string projectDirectoryFullName = projectFile.Directory.FullName;
+
+            if (!projectDirectoryFullName.StartsWith(solutionDirectoryFullName))
+                return string.Empty;
+
+            var projectAndSolutionFilesAreSameDirectory = projectDirectoryFullName.Equals(solutionDirectoryFullName);
+            if (projectAndSolutionFilesAreSameDirectory)
+                return string.Empty;
+
+            return projectDirectoryFullName.Substring(solutionDirectoryFullName.Length + 1);
+        }
+
+        private string ToValidFormat(string name)
+        {
+            return name
+                .Replace(' ', '_')
+                .Replace('-', '_')
+                .Replace("\\", "/")
+                .Replace('/', '.')
+                .Replace("..", ".")
+                .Trim('.');
+        }
+
+        protected string BuildNamespaceAccordingToOptions(
+          string solutionName,
+          string projectName,
+          string projectRootNamespace,
+          string projectToSolutionPhysicalPath,
+          string projectToSolutionVirtualPath,
+          string fileToProjectPath)
+        {
+            var newNamespace = GetOptions().NamespaceFormat;
+
+            Action<string, string> replaceWithFormat = (namespaceSection, sectionValue) =>
+            {
+                newNamespace = newNamespace.Replace(namespaceSection, "/" + sectionValue);
+            };
+
+            replaceWithFormat(NamespaceSections.SolutionName, solutionName);
+            replaceWithFormat(NamespaceSections.ProjectName, projectName);
+            replaceWithFormat(NamespaceSections.ProjectRootNamespace, projectRootNamespace);
+            replaceWithFormat(NamespaceSections.ProjectToSolutionPhysicalPath, projectToSolutionPhysicalPath);
+            replaceWithFormat(NamespaceSections.ProjectToSolutionVirtualPath, projectToSolutionVirtualPath);
+            replaceWithFormat(NamespaceSections.FileToProjectPath, fileToProjectPath);
+
+            return newNamespace;
+        }
+
+        private readonly INamespaceAdjusterOptions _options;
+
+        internal INamespaceAdjusterOptions GetOptions()
+        {
+            return _options;
+        }
+    }
+}

--- a/NamespaceFixer/NamespaceFixer.csproj
+++ b/NamespaceFixer/NamespaceFixer.csproj
@@ -74,6 +74,7 @@
     <Compile Include="NamespaceBuilder\INamespaceBuilder.cs" />
     <Compile Include="NamespaceBuilder\NamespaceBuilderService.cs" />
     <Compile Include="NamespaceBuilder\NamespaceSections.cs" />
+    <Compile Include="NamespaceBuilder\XamlNamespaceBuilderService.cs" />
     <Compile Include="OptionPage.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
Hello @pauer24,

It's not the cleaniest code in the world, but it seems to work for now.
Before refactoring this I want to ask you for some hints, or maybe you want to make refactoring by yourself:
* Currently `NamespaceBuilderFactory` is creating one instance of `INamespaceBuilder` per project/operation. What I want to achieve is creating `INamespaceBuilder` every file. How you would see this?
* `XamlNamespaceBuilderService` does not inherit `NamespaceBuilderService`, but it shares a lot of code. Do you mind if `NamespaceBuilderService` will consist three strategies for getting namespace, updating it, and creating a new one (stratetegy pattern)?

Issue ref #34 